### PR TITLE
Allow multiple color/styles to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation
 Accepted Colors
 ---------------
 
-black, red, green, yellow, blue, magenta, cyan, white, gray, grey
+black, red, green, yellow, blue, magenta, cyan, white, gray, grey, bgBlack, bgRed, bgGreen, bgYellow, bgBlue, bgMagenta, bgCyan, bgWhite, dim, rainbow, zebra, america, random, reset
 
 Usage
 -----
@@ -28,8 +28,8 @@ Usage
 		showMillis: true,
 		showTimestamp: true,
 		info: "gray",
-		error: "magenta",
-		debug: "white"
+		error: ["bgRed", "bold"],
+		debug: "rainbow"
 	};
 
 	var log = new Logger(customConfig) // custom config parameters will be used, defaults will be used for the other parameters
@@ -37,9 +37,9 @@ Usage
 
 	log.error("An error occurred"); // will be red
 	log.warn("I've got a bad feeling about this!"); // will be yellow
-	log.info('Something just happened, thought you should know!'); // will be green
-	log.debug('The value of x is: ' + x); // will be blue
-	log.trace('Heres some more stuff to help out.'); // will be gray
+	log.info("Something just happened, thought you should know!"); // will be green
+	log.debug("The value of x is: " + x); // will be blue
+	log.trace("Heres some more stuff to help out."); // will be gray
 ```
 
 Config options
@@ -51,11 +51,11 @@ For the `error`, `info`, `warn`, `debug`, and `trace` properties you can find th
 * `showMillis` - Show milliseconds in the timestamp.
 * `printObjFunc` - The function to apply objects to, if logged. Default is util.inspect.
 * `prefix` - String that is prepended to every message logged with this instance.
-* `error`- String that represents the color of the error text. Default is "red". 
-* `info`- String that represents the color of the info text. Default is "green".
-* `warn`- String that represents the color of the warning text. Default is "yellow".
-* `debug`- String that represents the color of the debug text. Default is "cyan".
-* `trace`- String that represents the color of the trace text. Default is "grey".
+* `error`- String or array that represents the color of the error text. Default is "red". 
+* `info`- String or array that represents the color of the info text. Default is "green".
+* `warn`- String or array that represents the color of the warning text. Default is "yellow".
+* `debug`- String or array that represents the color of the debug text. Default is "cyan".
+* `trace`- String or array that represents the color of the trace text. Default is "grey".
 
 Future versions
 ---------------

--- a/pretty-logger.js
+++ b/pretty-logger.js
@@ -15,6 +15,12 @@
 
     module.exports = PrettyLogger = (function () {
 
+        function formatForConfig (msg, config) {
+            return Array.isArray(config)
+                ? config.reduce(function (m, c) { return m[c]; }, msg)
+                : msg[config];
+        }
+        
         PrettyLogger.setLevel = BasicLogger.setLevel;
         function PrettyLogger(config) {
             if (config == null) config = {};
@@ -24,42 +30,42 @@
             BasicLogger.prototype.error = function () {
                 var args, msg;
                 msg = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-                args.unshift(msg[this.config.error], 'error');
+                args.unshift(formatForConfig(msg, this.config.error), 'error');
                 return this.log.apply(this, args);
             };
 
             BasicLogger.prototype.info = function () {
                 var args, msg;
                 msg = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-                args.unshift(msg[this.config.info], 'info');
+                args.unshift(formatForConfig(msg, this.config.info), 'info');
                 return this.log.apply(this, args);
             };
 
             BasicLogger.prototype.warn = function () {
                 var args, msg;
                 msg = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-                args.unshift(msg[this.config.warn], 'warning');
+                args.unshift(formatForConfig(msg, this.config.warn), 'warning');
                 return this.log.apply(this, args);
             };
 
             BasicLogger.prototype.warning = function () {
                 var args, msg;
                 msg = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-                args.unshift(msg[this.config.warn], 'warning');
+                args.unshift(formatForConfig(msg, this.config.warn), 'warning');
                 return this.log.apply(this, args);
             };
 
             BasicLogger.prototype.debug = function () {
                 var args, msg;
                 msg = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-                args.unshift(msg[this.config.debug], 'debug');
+                args.unshift(formatForConfig(msg, this.config.debug), 'debug');
                 return this.log.apply(this, args);
             };
 
             BasicLogger.prototype.trace = function () {
                 var args, msg;
                 msg = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
-                args.unshift(msg[this.config.trace], 'trace');
+                args.unshift(formatForConfig(msg, this.config.trace), 'trace');
                 return this.log.apply(this, args);
             };
 


### PR DESCRIPTION
The `colors` dependency allows for a range of background colors, text styles and random extras to be configured onto a string. With a slight modification, pretty-logger would eat arrays instead of just string configuration for the formatting of each log type. No breaking changes were made.